### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: other
   lifecycle: unknown
-  owner: user:default/debsmita1
+  owner: user:default/guest

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: other
   lifecycle: unknown
-  owner: user:default/guest
+  owner: user:default/debsmita1

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: other
   lifecycle: unknown
-  owner: user:default/frank.tiernan
+  owner: user:default/guest

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: new-dashboards
+  annotations:
+    github.com/project-slug: hacky-stuff/new-dashboards
+spec:
+  type: other
+  lifecycle: unknown
+  owner: user:default/debsmita1

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: other
   lifecycle: unknown
-  owner: user:default/guest
+  owner: user:default/frank.tiernan


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file**
to this repository so that the component can
be added to the [software catalog](https://redhat-developer-hub-deb-test.apps.lprabhu-120520251025.devcluster.openshift.com/catalog).
After this pull request is merged, the component will become available.
For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).
View the import job in your app [here](https://redhat-developer-hub-deb-test.apps.lprabhu-120520251025.devcluster.openshift.com/bulk-import/repositories?repository=https://github.com/hacky-stuff/new-dashboards&defaultBranch=main).